### PR TITLE
GUTTOK-51: 그룹 페이지 UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-label": "^2.1.1",
+        "@radix-ui/react-select": "^2.1.4",
         "@radix-ui/react-switch": "^1.1.2",
         "@radix-ui/react-toast": "^1.2.4",
         "@tanstack/react-query": "^5.62.8",
@@ -186,6 +187,40 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -878,11 +913,38 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.0.tgz",
+      "integrity": "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ=="
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
       "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.1.tgz",
+      "integrity": "sha512-NaVpZfmv8SKeZbn4ijN2V3jlHA9ngBG16VnIIm22nUR0Yk8KUALyBxT3KYEUnNuch9sTE8UTsS3whzBgKOL30w==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.1",
@@ -939,6 +1001,20 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.0.tgz",
+      "integrity": "sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-dismissable-layer": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.3.tgz",
@@ -965,6 +1041,61 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz",
+      "integrity": "sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.1.tgz",
+      "integrity": "sha512-01omzJAYRxXdG2/he/+xy+c8a8gCydoQ1yOxnWNcRhrrBW5W+RQJ22EK1SaO8tb3WoUsuEw7mJjBozPzihDFjA==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+      "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-label": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.1.tgz",
@@ -972,6 +1103,37 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.1.tgz",
+      "integrity": "sha512-3kn5Me69L+jv82EKRuQCXdYyf1DqHwD2U/sxoNgBGCB7K9TRc3bQamQ+5EPM9EvyPdli0W41sROd+ZU1dTCztw==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-rect": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0",
+        "@radix-ui/rect": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1057,11 +1219,52 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.1.4.tgz",
+      "integrity": "sha512-pOkb2u8KgO47j/h7AylCj7dJsm69BXcjkrvTqMptFqsE2i0p8lHkfgneXKjAgPzBMivnoMyt8o4KiV4wYzDdyQ==",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.3",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.1",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.1",
+        "@radix-ui/react-portal": "1.1.3",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-slot": "1.1.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.1",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "^2.6.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.1.tgz",
       "integrity": "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==",
-      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.1"
       },
@@ -1217,6 +1420,23 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
+      "integrity": "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-size": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
@@ -1256,6 +1476,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
+      "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg=="
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -1714,6 +1939,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -2369,6 +2605,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -3297,6 +3538,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-symbol-description": {
@@ -4976,6 +5225,72 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.2.tgz",
+      "integrity": "sha512-KmONPx5fnlXYJQqC62Q+lwIeAk64ws/cUw6omIumRzMRPqgnYqhSSti99nbj0Ry13bv7dF+BKn7NB+OqkdZGTw==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -5992,6 +6307,47 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-label": "^2.1.1",
+    "@radix-ui/react-select": "^2.1.4",
     "@radix-ui/react-switch": "^1.1.2",
     "@radix-ui/react-toast": "^1.2.4",
     "@tanstack/react-query": "^5.62.8",

--- a/src/app/group/[id]/edit/groupEditAction.ts
+++ b/src/app/group/[id]/edit/groupEditAction.ts
@@ -16,7 +16,7 @@ interface State {
   formData?: FormData
 }
 
-export async function groupAddAction(
+export async function groupEditAction(
   prevState: State | null,
   formData: FormData,
 ): Promise<State> {

--- a/src/app/group/[id]/edit/page.tsx
+++ b/src/app/group/[id]/edit/page.tsx
@@ -1,9 +1,164 @@
-export default async function GroupEdit({
-  params,
-}: {
-  params: Promise<{ id: number }>
-}) {
-  const groupId = (await params).id
-  
-  return <div>{groupId}</div>
+'use client'
+
+import { useActionState } from 'react'
+import { useParams } from 'next/navigation'
+import { Label } from '#components/_common/Label'
+import { Input } from '#components/_common/Input'
+import { ErrorMessage } from '#components/_common/ErrorMessage'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '#components/_common/Select'
+import { Textarea } from '#components/_common/TextArea'
+import { Button } from '#components/_common/Button'
+import {
+  CYCLE_LABELS,
+  CycleLabelsKey,
+  METHOD_LABELS,
+  MethodLabelsKey,
+} from '#constants/addServiceLabels'
+
+import { groupEditAction } from './groupEditAction'
+
+const data: {
+  name: string
+  price: number
+  date: number
+  cycle: CycleLabelsKey
+  method: MethodLabelsKey
+  description: string
+} = {
+  name: 'netflix',
+  price: 4700,
+  date: 1,
+  cycle: 'MONTHLY',
+  method: 'CARD',
+  description: 'string',
+}
+
+export default function GroupEdit() {
+  const params = useParams<{ id: string }>()
+  const groupId = parseInt(params.id)
+
+  const [state, handleSubmit, isPending] = useActionState(groupEditAction, {
+    data,
+  })
+
+  const formData = state?.formData
+  const errors = state?.errors
+
+  return (
+    <>
+      <div className="relative space-y-3 px-5 py-4 bg-secondary rounded-2xl shadow-sm">
+        <form action={handleSubmit} className="flex flex-col">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="name" className="text-gray-600">
+              그룹 이름
+            </Label>
+            <Input
+              name="name"
+              placeholder="그룹 이름을 입력하세요"
+              defaultValue={(formData?.get('name') as string) ?? data.name}
+            />
+            <ErrorMessage errors={errors?.name} />
+          </div>
+
+          <div className="flex flex-col gap-2 mt-4">
+            <Label htmlFor="price" className="text-gray-600">
+              결제 금액
+            </Label>
+            <Input
+              name="price"
+              type="number"
+              placeholder="결제 금액을 입력하세요"
+              defaultValue={(formData?.get('price') as string) ?? data.price}
+            />
+            <ErrorMessage errors={errors?.price} />
+          </div>
+
+          <div className="flex flex-col gap-2 mt-4">
+            <Label htmlFor="date" className="text-gray-600">
+              결제일
+            </Label>
+            <Input
+              name="date"
+              type="number"
+              placeholder="결제일을 입력하세요 (1~31)"
+              defaultValue={(formData?.get('date') as string) ?? data.date}
+            />
+            <ErrorMessage errors={errors?.date} />
+          </div>
+
+          <div className="flex flex-col gap-2 mt-4">
+            <Label htmlFor="cycle" className="text-gray-600">
+              납부 주기
+            </Label>
+            <Select
+              name="cycle"
+              defaultValue={(formData?.get('cycle') as string) ?? data.cycle}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="납부 주기를 선택하세요" />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(CYCLE_LABELS).map(([key, value]) => (
+                  <SelectItem key={key} value={key}>
+                    {value}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <ErrorMessage errors={errors?.cycle} />
+          </div>
+
+          <div className="flex flex-col gap-2 mt-4">
+            <Label htmlFor="method" className="text-gray-600">
+              결제 수단
+            </Label>
+            <Select
+              name="method"
+              defaultValue={(formData?.get('method') as string) ?? data.method}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="결제 수단을 선택하세요" />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(METHOD_LABELS).map(([key, value]) => (
+                  <SelectItem key={key} value={key}>
+                    {value}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <ErrorMessage errors={errors?.method} />
+          </div>
+
+          <div className="flex flex-col gap-2 mt-4">
+            <Label htmlFor="description" className="text-gray-600">
+              설명
+            </Label>
+            <Textarea
+              name="description"
+              placeholder="설명을 입력하세요"
+              defaultValue={
+                (formData?.get('description') as string) ?? data.description
+              }
+            />
+            <ErrorMessage errors={errors?.description} />
+          </div>
+
+          <Button
+            type="submit"
+            className="flex justify-self-center w-full h-10 text-md rounded-lg mt-10"
+            disabled={isPending}
+          >
+            수정하기
+          </Button>
+        </form>
+      </div>
+    </>
+  )
 }

--- a/src/app/group/[id]/edit/page.tsx
+++ b/src/app/group/[id]/edit/page.tsx
@@ -1,0 +1,9 @@
+export default async function GroupEdit({
+  params,
+}: {
+  params: Promise<{ id: number }>
+}) {
+  const groupId = (await params).id
+  
+  return <div>{groupId}</div>
+}

--- a/src/app/group/[id]/layout.tsx
+++ b/src/app/group/[id]/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react'
+
+export default function GroupDetailLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return (
+    <div className="sm:w-[calc(100vw-16rem)] sm:max-w-2xl m-4 sm:mx-auto sm:mt-8 space-y-4">
+      {children}
+    </div>
+  )
+}

--- a/src/app/group/[id]/member/InviteInput.tsx
+++ b/src/app/group/[id]/member/InviteInput.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { z } from 'zod'
+import { Input } from '#components/_common/Input'
+import { Label } from '#components/_common/Label'
+import { Button } from '#components/_common/Button'
+import { ErrorMessage } from '#components/_common/ErrorMessage'
+
+const emailSchema = z.string().email('유효하지 않은 이메일 형식입니다.')
+
+// Todo: mutate, refresh 작성
+export default function InviteInput() {
+  const emailInputRef = useRef<HTMLInputElement>(null)
+  const [errors, setErrors] = useState<string[] | undefined>(undefined)
+
+  // validation and mutate
+  const handleClick = () => {
+    const email = emailInputRef.current?.value
+
+    const validationResult = emailSchema.safeParse(email)
+    if (!validationResult.success) {
+      setErrors(validationResult.error.errors.map((err) => err.message))
+      return
+    }
+
+    setErrors(undefined)
+
+    if (emailInputRef.current) {
+      emailInputRef.current.value = ''
+    }
+  }
+
+  return (
+    <div className="space-y-1">
+      <div className="flex gap-2">
+        <Label className="w-full">
+          <Input
+            ref={emailInputRef}
+            type="email"
+            name="email"
+            placeholder="이메일 주소 입력"
+          />
+        </Label>
+        <Button onClick={handleClick}>초대</Button>
+      </div>
+      <ErrorMessage errors={errors} />
+    </div>
+  )
+}

--- a/src/app/group/[id]/member/page.tsx
+++ b/src/app/group/[id]/member/page.tsx
@@ -1,0 +1,9 @@
+export default async function GroupMemberEdit({
+  params,
+}: {
+  params: Promise<{ id: number }>
+}) {
+  const groupId = (await params).id
+
+  return <div>{groupId}</div>
+}

--- a/src/app/group/[id]/member/page.tsx
+++ b/src/app/group/[id]/member/page.tsx
@@ -1,3 +1,7 @@
+import { User } from 'lucide-react'
+import { Button } from '#components/_common/Button'
+import InviteInput from './InviteInput'
+
 export default async function GroupMemberEdit({
   params,
 }: {
@@ -5,5 +9,33 @@ export default async function GroupMemberEdit({
 }) {
   const groupId = (await params).id
 
-  return <div>{groupId}</div>
+  return (
+    <>
+      <div className="relative space-y-2 px-5 py-4 bg-secondary rounded-2xl shadow-sm">
+        <InviteInput />
+        <p className="text-gray-400 text-sm">
+          ※ 10명 이상은 초대할 수 없습니다
+        </p>
+      </div>
+      <div className="relative space-y-3 px-5 py-4 bg-secondary rounded-2xl shadow-sm">
+        <h3 className="font-semibold">초대된 참여자</h3>
+
+        <div className="flex items-center gap-3 w-full">
+          <div className="flex items-center justify-center w-12 h-12 bg-background rounded-full">
+            <User size={22} />
+          </div>
+          <div>
+            <p className="font-semibold">이영희</p>
+            <p className="text-sub">4,250원</p>
+          </div>
+          <Button
+            variant="ghost"
+            className="ml-auto p-0 h-[unset] text-destructive hover:bg-transparent hover:text-destructive/70"
+          >
+            삭제
+          </Button>
+        </div>
+      </div>
+    </>
+  )
 }

--- a/src/app/group/[id]/page.tsx
+++ b/src/app/group/[id]/page.tsx
@@ -1,0 +1,8 @@
+export default async function GroupItem({
+  params,
+}: {
+  params: Promise<{ id: number }>
+}) {
+  const groupId = (await params).id
+  return <div>My Post: {groupId}</div>
+}

--- a/src/app/group/[id]/page.tsx
+++ b/src/app/group/[id]/page.tsx
@@ -9,13 +9,13 @@ export default async function GroupDetail({
   params: Promise<{ id: number }>
 }) {
   const groupId = (await params).id
-  const leaderBgColor = 'bg-secondary-foreground/80'
-  const leaderIconColor = 'text-secondary'
+  const leaderBgColor = 'bg-primary/80'
+  const leaderIconColor = 'text-primary-foreground'
 
   const isLeader = true
 
   return (
-    <div className="sm:max-w-lg sm:w-full m-4 sm:m-auto space-y-4">
+    <>
       <div className="relative space-y-3 px-5 py-4 bg-secondary rounded-2xl shadow-sm">
         <h3 className="font-semibold">구독 정보</h3>
 
@@ -77,6 +77,6 @@ export default async function GroupDetail({
           </Link>
         )}
       </div>
-    </div>
+    </>
   )
 }

--- a/src/app/group/[id]/page.tsx
+++ b/src/app/group/[id]/page.tsx
@@ -1,8 +1,82 @@
-export default async function GroupItem({
+import Link from 'next/link'
+import { Crown, Settings, User } from 'lucide-react'
+import { cn } from '#components/lib/utils'
+import { PATH } from '#app/routes'
+
+export default async function GroupDetail({
   params,
 }: {
   params: Promise<{ id: number }>
 }) {
   const groupId = (await params).id
-  return <div>My Post: {groupId}</div>
+  const leaderBgColor = 'bg-secondary-foreground/80'
+  const leaderIconColor = 'text-secondary'
+
+  const isLeader = true
+
+  return (
+    <div className="sm:max-w-lg sm:w-full m-4 sm:m-auto space-y-4">
+      <div className="relative space-y-3 px-5 py-4 bg-secondary rounded-2xl shadow-sm">
+        <h3 className="font-semibold">구독 정보</h3>
+
+        <div>
+          <p className="text-lg">넷플릭스 프리이엄 4인</p>
+          <p className="text-xl font-semibold">17,000원/월</p>
+        </div>
+        <p className="text-gray-500">다음 결제일: 2024년 2월 15일</p>
+
+        <Link
+          href={PATH.groupEdit(groupId)}
+          className="absolute bottom-4 right-3 w-5 h-5 bg-transparent rounded-full"
+          aria-label="그룹 설정"
+        >
+          <Settings
+            className="w-full h-full text-gray-500"
+            aria-label="그룹 설정 아이콘"
+          />
+        </Link>
+      </div>
+
+      <div className="relative space-y-4 px-5 py-4 bg-secondary rounded-2xl shadow-sm">
+        <h3 className="font-semibold">참여자 목록 (2명)</h3>
+
+        <div className="flex items-center gap-3 w-full">
+          <div
+            className={cn(
+              'flex items-center justify-center w-12 h-12 bg-secondary-foreground rounded-full',
+              leaderBgColor,
+            )}
+          >
+            <Crown className={leaderIconColor} size={22} />
+          </div>
+          <div>
+            <p className="font-semibold">김하율 (관리자)</p>
+            <p className="text-sub">4,250원</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3 w-full">
+          <div className="flex items-center justify-center w-12 h-12 bg-background rounded-full">
+            <User size={22} />
+          </div>
+          <div>
+            <p className="font-semibold">이영희</p>
+            <p className="text-sub">4,250원</p>
+          </div>
+        </div>
+
+        {isLeader && (
+          <Link
+            href={PATH.groupMember(groupId)}
+            className="absolute bottom-4 right-3 w-5 h-5 bg-transparent rounded-full"
+            aria-label="멤버 설정"
+          >
+            <Settings
+              className="w-full h-full text-gray-500"
+              aria-label="멤버 설정 아이콘"
+            />
+          </Link>
+        )}
+      </div>
+    </div>
+  )
 }

--- a/src/app/group/add/groupAddAction.ts
+++ b/src/app/group/add/groupAddAction.ts
@@ -1,0 +1,78 @@
+'use server'
+
+import { z } from 'zod'
+import {
+  CycleEnum,
+  CycleLabelsKey,
+  MethodEnum,
+  MethodLabelsKey,
+} from '#constants/addServiceLabels'
+
+const groupAddSchema = z.object({
+  name: z.string().min(3, '이름은 최소 3자 이상이어야 합니다.'),
+  price: z
+    .number({
+      invalid_type_error: '가격은 숫자 형식이어야 합니다.',
+    })
+    .int('가격은 정수여야 합니다.')
+    .positive('가격은 양수여야 합니다.')
+    .max(1000000, '가격은 1,000,000 이하이어야 합니다.'),
+  date: z
+    .number({
+      invalid_type_error: '결제일은 숫자 형식이어야 합니다.',
+    })
+    .int('결제일은 정수여야 합니다.')
+    .min(1, '결제일은 최소 1이어야 합니다.')
+    .max(31, '결제일은 최대 31이어야 합니다.'),
+  cycle: z.enum(CycleEnum, {
+    errorMap: () => ({
+      message: '납부 주기는 연간, 매월, 매주 중 하나여야 합니다.',
+    }),
+  }),
+  method: z.enum(MethodEnum, {
+    errorMap: () => ({
+      message: '결제 수단은 카드 또는 계좌이체여야 합니다.',
+    }),
+  }),
+  description: z.string().max(500, '설명은 500자 이내로 작성해야 합니다.'),
+})
+
+interface State {
+  data?: {
+    name: string
+    price: number
+    date: number
+    cycle: CycleLabelsKey
+    method: MethodLabelsKey
+    description: string
+  }
+  errors?: Record<string, string[]>
+  formData?: FormData
+}
+
+export async function groupAddAction(
+  prevState: State | null,
+  formData: FormData,
+): Promise<State> {
+  const input = {
+    name: formData.get('name'),
+    price: parseInt(formData.get('price') as string),
+    date: parseInt(formData.get('date') as string),
+    cycle: formData.get('cycle'),
+    method: formData.get('method'),
+    description: formData.get('description'),
+  }
+
+  const parseResult = groupAddSchema.safeParse(input)
+  if (!parseResult.success) {
+    const errors = parseResult.error.flatten().fieldErrors
+    return {
+      errors,
+      formData,
+    }
+  }
+
+  // Todo: API 호출 및 return
+
+  return {}
+}

--- a/src/app/group/add/page.tsx
+++ b/src/app/group/add/page.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { useActionState } from 'react'
+import { Label } from '#components/_common/Label'
+import { Input } from '#components/_common/Input'
+import { ErrorMessage } from '#components/_common/ErrorMessage'
+import { Button } from '#components/_common/Button'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '#components/_common/Select'
+import { Textarea } from '#components/_common/TextArea'
+import { CYCLE_LABELS, METHOD_LABELS } from '#constants/addServiceLabels'
+import { groupAddAction } from './groupAddAction'
+
+export default function GroupAdd() {
+  const [state, handleSubmit, isPending] = useActionState(groupAddAction, null)
+
+  const formData = state?.formData
+  const errors = state?.errors
+
+  return (
+    <div className="sm:max-w-lg sm:w-full m-4 sm:m-auto px-5 py-6 bg-secondary rounded-2xl shadow-sm">
+      <form action={handleSubmit} className="flex flex-col">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="name" className="text-gray-600">
+            그룹 이름
+          </Label>
+          <Input
+            name="name"
+            placeholder="그룹 이름을 입력하세요"
+            defaultValue={formData?.get('name') as string}
+          />
+          <ErrorMessage errors={errors?.name} />
+        </div>
+
+        <div className="flex flex-col gap-2 mt-4">
+          <Label htmlFor="price" className="text-gray-600">
+            결제 금액
+          </Label>
+          <Input
+            name="price"
+            type="number"
+            placeholder="결제 금액을 입력하세요"
+            defaultValue={formData?.get('price') as string}
+          />
+          <ErrorMessage errors={errors?.price} />
+        </div>
+
+        <div className="flex flex-col gap-2 mt-4">
+          <Label htmlFor="date" className="text-gray-600">
+            결제일
+          </Label>
+          <Input
+            name="date"
+            type="number"
+            placeholder="결제일을 입력하세요 (1~31)"
+            defaultValue={formData?.get('date') as string}
+          />
+          <ErrorMessage errors={errors?.date} />
+        </div>
+
+        <div className="flex flex-col gap-2 mt-4">
+          <Label htmlFor="cycle" className="text-gray-600">
+            납부 주기
+          </Label>
+          <Select name="cycle" defaultValue={formData?.get('cycle') as string}>
+            <SelectTrigger>
+              <SelectValue placeholder="납부 주기를 선택하세요" />
+            </SelectTrigger>
+            <SelectContent>
+              {Object.entries(CYCLE_LABELS).map(([key, value]) => (
+                <SelectItem key={key} value={key}>
+                  {value}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <ErrorMessage errors={errors?.cycle} />
+        </div>
+
+        <div className="flex flex-col gap-2 mt-4">
+          <Label htmlFor="method" className="text-gray-600">
+            결제 수단
+          </Label>
+          <Select
+            name="method"
+            defaultValue={formData?.get('method') as string}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="결제 수단을 선택하세요" />
+            </SelectTrigger>
+            <SelectContent>
+              {Object.entries(METHOD_LABELS).map(([key, value]) => (
+                <SelectItem key={key} value={key}>
+                  {value}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <ErrorMessage errors={errors?.method} />
+        </div>
+
+        <div className="flex flex-col gap-2 mt-4">
+          <Label htmlFor="description" className="text-gray-600">
+            설명
+          </Label>
+          <Textarea
+            name="description"
+            placeholder="설명을 입력하세요"
+            defaultValue={formData?.get('description') as string}
+          />
+          <ErrorMessage errors={errors?.description} />
+        </div>
+
+        <Button
+          type="submit"
+          className="flex justify-self-center w-full h-10 text-md rounded-lg mt-10"
+          disabled={isPending}
+        >
+          만들기
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/src/app/group/add/page.tsx
+++ b/src/app/group/add/page.tsx
@@ -23,7 +23,7 @@ export default function GroupAdd() {
   const errors = state?.errors
 
   return (
-    <div className="sm:max-w-lg sm:w-full m-4 sm:m-auto px-5 py-6 bg-secondary rounded-2xl shadow-sm">
+    <div className="sm:w-[calc(100vw-16rem)] sm:max-w-2xl m-4 sm:mx-auto sm:mt-8 px-5 py-6 bg-secondary rounded-2xl shadow-sm">
       <form action={handleSubmit} className="flex flex-col">
         <div className="flex flex-col gap-2">
           <Label htmlFor="name" className="text-gray-600">

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -1,36 +1,48 @@
-import { CalendarRange, ReceiptText } from 'lucide-react'
+import Link from 'next/link'
+import { CalendarRange, Plus, ReceiptText } from 'lucide-react'
 import { Button } from '#components/_common/Button'
+import { PATH } from '#app/routes'
 
 export default function Group() {
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 gap-10 m-4 sm:m-10">
-      <div className="p-6 bg-secondary rounded-xl shadow-sm">
-        <div className="flex flex-col lg:flex-row justify-between items-center gap-2 lg:gap-0">
-          <p className="text-lg font-semibold">넷플릭스 프리이엄 4인</p>
-          <p className="px-3 py-1 text-sm text-primary bg-primary/20 rounded-2xl">
-            다음 결제일: 2024.02.15
-          </p>
-        </div>
+    <>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-10 m-4 sm:m-10">
+        <div className="p-6 bg-secondary rounded-xl shadow-sm">
+          <div className="flex flex-col lg:flex-row justify-between items-center gap-2 lg:gap-0">
+            <p className="text-lg font-semibold">넷플릭스 프리이엄 4인</p>
+            <p className="px-3 py-1 text-sm text-primary bg-primary/20 rounded-2xl">
+              다음 결제일: 2024.02.15
+            </p>
+          </div>
 
-        <div className="flex flex-col">
-          <div className="flex gap-3 mt-4">
-            <ReceiptText size={18} className="mt-[3px]" />
-            <div className="flex flex-col">
-              <p className="font-medium">월 납부금액</p>
-              <p className="text-sm text-gray-500">4,500원/ (4인 분배)</p>
+          <div className="flex flex-col">
+            <div className="flex gap-3 mt-4">
+              <ReceiptText size={18} className="mt-[3px]" />
+              <div className="flex flex-col">
+                <p className="font-medium">월 납부금액</p>
+                <p className="text-sm text-gray-500">4,500원/ (4인 분배)</p>
+              </div>
+            </div>
+            <div className="flex gap-3 mt-4">
+              <CalendarRange size={18} className="mt-[3px]" />
+              <div className="flex flex-col">
+                <p className="font-medium">구독 상태</p>
+                <p className="text-sm text-gray-500">정상 이용 중</p>
+              </div>
             </div>
           </div>
-          <div className="flex gap-3 mt-4">
-            <CalendarRange size={18} className="mt-[3px]" />
-            <div className="flex flex-col">
-              <p className="font-medium">구독 상태</p>
-              <p className="text-sm text-gray-500">정상 이용 중</p>
-            </div>
-          </div>
-        </div>
 
-        <Button className="w-full mt-4 rounded-lg">그룹으로 이동</Button>
+          <Button className="w-full mt-4 rounded-lg">그룹으로 이동</Button>
+        </div>
       </div>
-    </div>
+
+      <Link
+        href={PATH.groupAdd}
+        className="absolute bottom-6 right-6 flex items-center justify-center w-12 h-12 bg-primary text-primary-foreground rounded-full shadow-lg"
+        aria-label="그룹 추가하기"
+      >
+        <Plus size={20} strokeWidth={3} aria-label="추가하기 아이콘" />
+      </Link>
+    </>
   )
 }

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -5,7 +5,7 @@ import { PATH } from '#app/routes'
 export default function Group() {
   return (
     <>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-10 m-4 sm:m-10">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-10 sm:w-[calc(100vw-16rem)] sm:max-w-[60rem] m-4 sm:mx-auto sm:mt-8">
         <div className="p-6 bg-secondary rounded-xl shadow-sm">
           <div className="flex flex-col lg:flex-row justify-between items-center gap-2 lg:gap-0">
             <p className="text-lg font-semibold">넷플릭스 프리이엄 4인</p>

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link'
 import { CalendarRange, Plus, ReceiptText } from 'lucide-react'
-import { Button } from '#components/_common/Button'
 import { PATH } from '#app/routes'
 
 export default function Group() {
@@ -32,7 +31,12 @@ export default function Group() {
             </div>
           </div>
 
-          <Button className="w-full mt-4 rounded-lg">그룹으로 이동</Button>
+          <Link
+            href={PATH.groupDetail(1)}
+            className="flex w-full justify-center mt-4 p-2 text-sm bg-primary text-primary-foreground rounded-lg"
+          >
+            그룹으로 이동
+          </Link>
         </div>
       </div>
 

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -1,0 +1,36 @@
+import { CalendarRange, ReceiptText } from 'lucide-react'
+import { Button } from '#components/_common/Button'
+
+export default function Group() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-10 m-4 sm:m-10">
+      <div className="p-6 bg-secondary rounded-xl shadow-sm">
+        <div className="flex flex-col lg:flex-row justify-between items-center gap-2 lg:gap-0">
+          <p className="text-lg font-semibold">넷플릭스 프리이엄 4인</p>
+          <p className="px-3 py-1 text-sm text-primary bg-primary/20 rounded-2xl">
+            다음 결제일: 2024.02.15
+          </p>
+        </div>
+
+        <div className="flex flex-col">
+          <div className="flex gap-3 mt-4">
+            <ReceiptText size={18} className="mt-[3px]" />
+            <div className="flex flex-col">
+              <p className="font-medium">월 납부금액</p>
+              <p className="text-sm text-gray-500">4,500원/ (4인 분배)</p>
+            </div>
+          </div>
+          <div className="flex gap-3 mt-4">
+            <CalendarRange size={18} className="mt-[3px]" />
+            <div className="flex flex-col">
+              <p className="font-medium">구독 상태</p>
+              <p className="text-sm text-gray-500">정상 이용 중</p>
+            </div>
+          </div>
+        </div>
+
+        <Button className="w-full mt-4 rounded-lg">그룹으로 이동</Button>
+      </div>
+    </div>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
         <QueryProvider>
           <ThemeProvider>
             <Layout>
-              <main className="flex flex-col w-full sm:w-[calc(100%-224px)] sm:float-right h-[calc(100vh-72px)] sm:h-[100vh] overflow-y-auto">
+              <main className="relative flex flex-col w-full sm:w-[calc(100%-224px)] sm:float-right h-[calc(100vh-72px)] sm:h-[100vh] overflow-y-auto">
                 {children}
               </main>
             </Layout>

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -17,4 +17,7 @@ export const PATH = {
 
   group: '/group',
   groupAdd: '/group/add',
+  groupDetail: (groupId: number) => `/group/${groupId}`,
+  groupEdit: (groupId: number) => `/group/${groupId}/edit`,
+  groupMember: (groupId: number) => `/group/${groupId}/member`,
 }

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -1,17 +1,20 @@
 export const PATH = {
   listView: '/',
   calendarView: '',
-  group: '',
   notification: '',
   myPage: '',
+
   login: '/login',
   register: '/register',
   forgotEmail: '/forgot/email',
   forgotPassword: '/forgot/password',
-  
+
   add: 'item/add',
   addDetail: 'item/add/detail',
   addCustom: 'item/add/detail/custom',
   delete: 'item/delete',
   modify: 'item/modify',
+
+  group: '/group',
+  groupAdd: '/group/add',
 }

--- a/src/components/_common/Select/index.tsx
+++ b/src/components/_common/Select/index.tsx
@@ -1,0 +1,159 @@
+"use client"
+
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { Check, ChevronDown, ChevronUp } from "lucide-react"
+
+import { cn } from "#components/lib/utils"
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+))
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+))
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+    {...props}
+  />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+}

--- a/src/components/_common/TextArea/index.tsx
+++ b/src/components/_common/TextArea/index.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "#components/lib/utils"
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<"textarea">
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+Textarea.displayName = "Textarea"
+
+export { Textarea }

--- a/src/constants/addServiceLabels.ts
+++ b/src/constants/addServiceLabels.ts
@@ -1,0 +1,22 @@
+export const CYCLE_LABELS = {
+  YEARLY: '연간',
+  MONTHLY: '매월',
+  WEEKLY: '매주',
+} as const
+
+export const METHOD_LABELS = {
+  CARD: '카드',
+  BANK_TRANSFER: '계좌이체',
+} as const
+
+export type CycleLabelsKey = keyof typeof CYCLE_LABELS
+export type MethodLabelsKey = keyof typeof METHOD_LABELS
+
+export const CycleEnum = Object.keys(CYCLE_LABELS) as [
+  CycleLabelsKey,
+  ...CycleLabelsKey[],
+]
+export const MethodEnum = Object.keys(METHOD_LABELS) as [
+  MethodLabelsKey,
+  ...MethodLabelsKey[],
+]

--- a/src/schemas/groupSchema.ts
+++ b/src/schemas/groupSchema.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod'
+import { CycleEnum, MethodEnum } from '#constants/addServiceLabels'
+
+export const groupSchema = z.object({
+  name: z.string().min(3, '이름은 최소 3자 이상이어야 합니다.'),
+  price: z
+    .number({
+      invalid_type_error: '가격은 숫자 형식이어야 합니다.',
+    })
+    .int('가격은 정수여야 합니다.')
+    .positive('가격은 양수여야 합니다.')
+    .max(1000000, '가격은 1,000,000 이하이어야 합니다.'),
+  date: z
+    .number({
+      invalid_type_error: '결제일은 숫자 형식이어야 합니다.',
+    })
+    .int('결제일은 정수여야 합니다.')
+    .min(1, '결제일은 최소 1이어야 합니다.')
+    .max(31, '결제일은 최대 31이어야 합니다.'),
+  cycle: z.enum(CycleEnum, {
+    errorMap: () => ({
+      message: '납부 주기는 연간, 매월, 매주 중 하나여야 합니다.',
+    }),
+  }),
+  method: z.enum(MethodEnum, {
+    errorMap: () => ({
+      message: '결제 수단은 카드 또는 계좌이체여야 합니다.',
+    }),
+  }),
+  description: z.string().max(500, '설명은 500자 이내로 작성해야 합니다.'),
+})


### PR DESCRIPTION
## 요약

그룹 리스트, 그룹 생성, 그룹 상세보기, 그룹 수정, 그룹원 관리 페이지 UI 를 작성했습니다.

<br>

## 작업 내용

- 로그인과 마찬가지로 그룹 생성 및 수정에 관한 form은 useActionState와 server action의 조합으로 구성
- 그룹원 추가 및 삭제는 따로 client component로 분리하여 mutate로 처리할 수 있게 구성
- 전반적인 라우팅 설정은 아래와 같습니다.
```ts
{
  group: '/group',
  groupAdd: '/group/add',
  groupDetail: (groupId: number) => `/group/${groupId}`,
  groupEdit: (groupId: number) => `/group/${groupId}/edit`,
  groupMember: (groupId: number) => `/group/${groupId}/member`,
}
```

<br>

## 기타 메시지

구상된 디자인에 대해 반응형 처리를 위해서는 css만으로는 현재 처리할 수 없는(html 태그 상이) 부분이 있습니다.

따라서 해당 PR은 모바일 화면을 중심으로 css로 반응형 처리를 한 상태이며, 이 부분은 다음 회의 때 자세히 말씀드리겠습니다.

<br>
