### PR TITLE
GUTTOK-68: 마이페이지 UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@radix-ui/react-popover": "^1.1.4",
         "@radix-ui/react-select": "^2.1.4",
         "@radix-ui/react-slot": "^1.1.1",
-        "@radix-ui/react-select": "^2.1.4",
         "@radix-ui/react-switch": "^1.1.2",
         "@radix-ui/react-toast": "^1.2.4",
         "@tanstack/react-query": "^5.62.8",

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -2,7 +2,6 @@ export const PATH = {
   listView: '/',
   calendarView: '',
   notification: '',
-  myPage: '',
 
   login: '/login',
   register: '/register',
@@ -18,4 +17,7 @@ export const PATH = {
   groupDetail: (groupId: number) => `/group/${groupId}`,
   groupEdit: (groupId: number) => `/group/${groupId}/edit`,
   groupMember: (groupId: number) => `/group/${groupId}/member`,
+
+  myPage: '/settings',
+  myPageEdit: '/settings/edit',
 }

--- a/src/app/settings/RemindSwitch.tsx
+++ b/src/app/settings/RemindSwitch.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useState } from 'react'
+import { Switch } from '#components/_common/Switch'
+
+export default function RemindSwitch({
+  initialChecked,
+}: {
+  initialChecked: boolean
+}) {
+  const [checked, setChecked] = useState(initialChecked)
+
+  const handleToggle = async () => {
+    const newChecked = !checked
+    setChecked(newChecked)
+  }
+
+  return <Switch checked={checked} onCheckedChange={handleToggle} />
+}

--- a/src/app/settings/edit/MyPageEditForm.tsx
+++ b/src/app/settings/edit/MyPageEditForm.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import { useActionState } from 'react'
+import type { UserDetail } from '#types/user'
+
+import { Input } from '#components/_common/Input'
+import { Label } from '#components/_common/Label'
+import { Button } from '#components/_common/Button'
+import { ErrorMessage } from '#components/_common/ErrorMessage'
+
+import { myPageEditAction } from './myPageEditAction'
+
+export default function MyPageEditForm({
+  initialData,
+}: {
+  initialData: UserDetail
+}) {
+  const [state, handleSubmit, isPending] = useActionState(
+    myPageEditAction,
+    null,
+  )
+
+  const formData = state?.formData
+  const errors = state?.errors
+
+  const getDefaultValue = (field: keyof UserDetail): string => {
+    const formValue = formData?.get(field)
+    if (formValue !== null && formValue !== undefined) {
+      return formValue.toString()
+    }
+    return initialData[field]?.toString() ?? ''
+  }
+
+  return (
+    <form action={handleSubmit} className="w-full p-5">
+      <div className="flex justify-between items-center mb-4">
+        <p className="text-lg font-semibold">프로필 정보</p>
+      </div>
+
+      <div className="felx flex-col">
+        <div className="flex justify-between items-center gap-3 mb-2">
+          <Label htmlFor="nickname" className="text-gray-600">
+            닉네임
+          </Label>
+          <Input
+            id="nickname"
+            name="nickname"
+            type="text"
+            placeholder="닉네임을 입력하세요"
+            className="w-0 grow max-w-60"
+            defaultValue={getDefaultValue('nickName')}
+          />
+        </div>
+        <ErrorMessage errors={errors?.nickname} className="mb-2" />
+      </div>
+
+      <div className="felx flex-col">
+        <div className="flex justify-between items-center gap-3 mb-2">
+          <Label htmlFor="email" className="text-gray-600">
+            이메일
+          </Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="이메일을 입력하세요"
+            className="w-0 grow max-w-60"
+            defaultValue={getDefaultValue('email')}
+          />
+        </div>
+        <ErrorMessage errors={errors?.email} className="mb-2" />
+      </div>
+
+      <div className="felx flex-col">
+        <div className="flex justify-between items-center gap-3 mb-2">
+          <Label htmlFor="password" className="text-gray-600">
+            비밀번호
+          </Label>
+          <Input
+            id="password"
+            name="password"
+            type="password"
+            placeholder="비밀번호을 입력하세요"
+            className="w-0 grow max-w-60"
+            defaultValue={formData?.get('password') as string}
+          />
+        </div>
+        <ErrorMessage errors={errors?.password} className="mb-2" />
+      </div>
+
+      <div className="felx flex-col">
+        <div className="flex justify-between items-center gap-3 mb-2">
+          <Label
+            htmlFor="password-confirm"
+            className="text-center text-gray-600"
+          >
+            비밀번호 <br /> 확인
+          </Label>
+          <Input
+            id="password-confirm"
+            name="password-confirm"
+            type="password"
+            placeholder="비밀번호를 입력하세요"
+            className="w-0 grow max-w-60"
+            defaultValue={formData?.get('password-confirm') as string}
+          />
+        </div>
+        <ErrorMessage errors={errors?.passwordConfirm} className="mb-2" />
+      </div>
+
+      <div className="px-10 mt-10">
+        <Button disabled={isPending} className="w-full rounded-lg">
+          저장하기
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/src/app/settings/edit/myPageEditAction.ts
+++ b/src/app/settings/edit/myPageEditAction.ts
@@ -13,7 +13,7 @@ interface State {
   formData?: FormData
 }
 
-export async function registerAction(
+export async function myPageEditAction(
   prevState: State | null,
   formData: FormData,
 ): Promise<State> {
@@ -21,7 +21,6 @@ export async function registerAction(
     email: formData.get('email'),
     password: formData.get('password'),
     nickname: formData.get('nickname'),
-    session: formData.get('session'),
   }
 
   console.log(input)

--- a/src/app/settings/edit/page.tsx
+++ b/src/app/settings/edit/page.tsx
@@ -1,0 +1,26 @@
+import MyPageEditForm from '#app/settings/edit/MyPageEditForm'
+import { UserDetail } from '#types/user'
+
+function getInitialData(): UserDetail {
+  return {
+    id: 1,
+    email: 'email@example.com',
+    nickName: 'guttok',
+    alarm: true,
+  }
+}
+
+export default function MyPageEdit() {
+  const initialData = getInitialData()
+
+  return (
+    <div className="flex flex-col justify-center items-center">
+      <div className="flex flex-col items-center w-full mt-5">
+        <h2 className="text-xl sm:text-3xl font-bold">마이페이지 수정</h2>
+      </div>
+      <div className="w-full h-[1px] bg-border mt-5"></div>
+
+      <MyPageEditForm initialData={initialData} />
+    </div>
+  )
+}

--- a/src/app/settings/layout.tsx
+++ b/src/app/settings/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react'
+
+export default function MyPageLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-col items-center sm:m-auto sm:-translate-y-12">
+      <div className="w-full sm:w-[60vw] sm:max-w-[832px] sm:p-8 sm:rounded-md sm:border sm:border-border">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link'
+import { PATH } from '#app/routes'
+import RemindSwitch from './RemindSwitch'
+
+export default function MyPage() {
+  return (
+    <div className="flex flex-col justify-center items-center">
+      <div className="flex flex-col items-center w-full mt-5">
+        <h2 className="text-xl sm:text-3xl font-bold">마이페이지</h2>
+      </div>
+      <div className="w-full h-[1px] bg-border mt-5"></div>
+
+      <div className="w-full p-5">
+        <div className="flex justify-between items-center mb-4">
+          <p className="text-lg font-semibold">프로필 정보</p>
+          <Link
+            href={PATH.myPageEdit}
+            className="flex items-center px-3 h-8 rounded-2xl bg-primary text-primary-foreground text-sm"
+          >
+            정보 수정
+          </Link>
+        </div>
+        <div className="flex justify-between mb-2">
+          <p className="text-gray-600">닉네임</p>
+          <div>구똑</div>
+        </div>
+        <div className="flex justify-between mb-2">
+          <p className="text-gray-600">이메일</p>
+          <div>email@example.com</div>
+        </div>
+      </div>
+
+      <div className="w-full p-5">
+        <div className="flex justify-between items-center mb-4">
+          <p className="text-lg font-semibold">알림 설정</p>
+        </div>
+        <div className="flex justify-between mb-2">
+          <p className="text-gray-600">납부 리마인드</p>
+          <RemindSwitch initialChecked={true} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/schemas/userSchema.ts
+++ b/src/schemas/userSchema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+export const userSchema = z.object({
+  nickname: z.string().min(3, '닉네임은 최소 3자 이상이어야 합니다.'),
+  email: z.string().email('유효한 이메일 주소를 입력하세요.'),
+  password: z
+    .string()
+    .min(
+      12,
+      '특수문자(@$!%*?&#), 영어 소문자, 숫자를 포함한 12자 이상이어야 합니다.',
+    )
+    .regex(
+      /^(?=.*[a-z])(?=.*\d)(?=.*[@$!%*?&#])[A-Za-z\d@$!%*?&#]{12,}$/,
+      '특수문자(@$!%*?&#), 영어 소문자, 숫자를 포함해야 합니다.',
+    ),
+  session: z.string().min(1, '새로고침하여 다시 이메일을 인증해 주세요'),
+})

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,6 @@
+export interface UserDetail {
+  id: number
+  email: string
+  nickName: string
+  alarm: boolean
+}


### PR DESCRIPTION
## 요약

아래의 라우팅 경로에 해당하는 마이페이지에 대한 UI를 구성했습니다
- /settings
- /settings/edit

<br>

## 작업 내용

- 서버 컴포넌트에서 초기 데이터를 fetch한 후, 클라이언트 컴포넌트에서 처리
- 리마인드 알림 토글 버튼은 react-query mutate를 이용할 수 있도록 구성
- 마이페이지 정보 수정은 useActionState 와 server action 으로 form 구성
- UserDetail 타입 정의 및 userSchema 스키마 정의


<br>

## 기타 메시지

<br>
