### PR TITLE
fix: 클라이언트 경로로 요청 보내는 이슈 수정

### DIFF
--- a/src/apis/authAPI.ts
+++ b/src/apis/authAPI.ts
@@ -1,5 +1,5 @@
 // 회원가입 / 로그인 / 로그아웃 / 회원가입 이메일 인증번호 발송 / 회원가입 이메일 인증번호 검증 / 비밀번호 찾기 인증번호 검증
-//
+
 'use server'
 
 import { BASE_URL } from '#constants/url'
@@ -64,22 +64,22 @@ export async function useLogin({
 }
 
 // 인증번호 발송 post
-export async function sendCertificationCode(email: string) {
-  const res = await fetch(`${BASE_URL}/api/mail/certification`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
-    body: JSON.stringify({
-      email,
-    }),
-  })
+// export async function sendCertificationCode(email: string) {
+//   const res = await fetch(`${BASE_URL}/api/mail/certification`, {
+//     method: 'POST',
+//     headers: { 'Content-Type': 'application/json' },
+//     credentials: 'include',
+//     body: JSON.stringify({
+//       email,
+//     }),
+//   })
 
-  if (!res.ok) {
-    throw new Error(`HTTP 에러: ${res.status}` && `인증번호 요청 실패`)
-  }
+//   if (!res.ok) {
+//     throw new Error(`HTTP 에러: ${res.status}` && `인증번호 요청 실패`)
+//   }
 
-  return res.json()
-}
+//   return res.json()
+// }
 
 // 회원가입 인증번호 검증 post
 export async function verifyRegisterCode({

--- a/src/apis/authClient.ts
+++ b/src/apis/authClient.ts
@@ -4,7 +4,7 @@ import { useAuthStore } from '#stores/auth/useAuthStore'
 import { useMutation } from '@tanstack/react-query'
 import { BASE_URL } from '#constants/url'
 import {
-  sendCertificationCode,
+  //sendCertificationCode,
   register,
   verifyRegisterCode,
   verifyPasswordCode,
@@ -89,7 +89,20 @@ export const useLogoutClient = () => {
 // 인증번호 발송 post
 export const useSendCertificationCode = () => {
   return useMutation({
-    mutationFn: (email: string) => sendCertificationCode(email),
+    mutationFn: async (email: string) => {
+      const res = await fetch(`${BASE_URL}/api/mail/certification`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ email }),
+      })
+
+      if (!res.ok) {
+        throw new Error(`${res.status}` || '인증번호 요청 실패')
+      }
+      return res.json()
+    },
+
     onSuccess: (res) => {
       console.log('발송 성공:', res.message)
     },


### PR DESCRIPTION
회원가입 페이지 (/register)에서 인증번호 발송 api를 요청 -> /api/mail/certification 가 아닌 /register (클라이언트 경로 register/page.tsx)로 요청 보내는 이슈 수정 중